### PR TITLE
Update README caching info

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project introduces an interactive and recursive polarchart designed to map 
 - Recursive multi-layer polarchart frontend editor
 - Real-time update in SVG format using D3.js
 - Export options (SVG and PNG)
-- Cached data to resume session
+- Cached data to resume session (chart data and settings persisted via `localStorage`)
 - Excel Import/Export
 
 ## Technologies Used


### PR DESCRIPTION
## Summary
- clarify that cached chart data and settings use `localStorage`

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f5f6954b88327a47e5160f98e3e12